### PR TITLE
Comment out import for org.kde.plasma.components version 3.

### DIFF
--- a/package/contents/ui/TodoItemDelegate.qml
+++ b/package/contents/ui/TodoItemDelegate.qml
@@ -3,7 +3,7 @@ import QtQuick.Controls 1.1
 import QtQuick.Layouts 1.1
 import org.kde.plasma.core 2.0 as PlasmaCore
 import org.kde.plasma.components 2.0 as PlasmaComponents
-import org.kde.plasma.components 3.0 as PlasmaComponents3
+// import org.kde.plasma.components 3.0 as PlasmaComponents3
 import QtQuick.Controls.Styles.Plasma 2.0 as PlasmaStyles
 import org.kde.draganddrop 2.0 as DragAndDrop
 
@@ -143,14 +143,14 @@ MouseArea {
 			Layout.fillWidth: true
 			Layout.alignment: Qt.AlignTop
 
-			
+
 			TextArea {
 			// PlasmaFlatStyle.FastTextArea {
 			// PlasmaComponents3.TextArea {
 				id: textArea
 				width: parent.width
 				// Layout.fillHeight: true
-				
+
 				// height: {
 				// 	console.log(leftPadding)
 				// 	return Math.max(leftPadding * 2 + font.pixelSize, implicitHeight)
@@ -230,7 +230,7 @@ MouseArea {
 					out = out.replace(/[\u00A0-\u9999<>\&]/gim, function(i) {
 						return '&#' + i.charCodeAt(0) + ';'
 					})
-					
+
 					// Render links
 					var rUrl = /(http|https):\/\/[\w-]+(\.[\w-]+)+([\w.,@?^=%&amp;:\/~+#-]*[\w@?^=%&amp;\/~+#-])?/gi
 					out = out.replace(rUrl, function(m) {
@@ -290,7 +290,7 @@ MouseArea {
 					}
 				}
 			}
-			
+
 		}
 
 		PlasmaComponents.ToolButton {

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -47,7 +47,7 @@ Item {
 			anchors.fill: parent
 			source: plasmoid.icon
 		}
-			
+
 		IconCounterOverlay {
 			anchors.fill: parent
 			text: noteItem.incompleteCount
@@ -125,7 +125,7 @@ Item {
 
 	Component.onCompleted: {
 		plasmoid.setAction("openInTextEditor", i18n("Open in Text Editor"), "accessories-text-editor")
-		plasmoid.setAction("addSection", i18n("Add List"), "list-add")
+// 		plasmoid.setAction("addSection", i18n("Add List"), "list-add")
 		plasmoid.setAction("toggleDeleteOnComplete", i18n("Delete on Complete"), "checkmark")
 		plasmoid.setAction("toggleHidden", i18n("Hide"), "checkmark")
 		// plasmoid.setAction("deleteCompleted", i18n("Delete All Completed"), "trash-empty")

--- a/package/translate/ReadMe.md
+++ b/package/translate/ReadMe.md
@@ -34,5 +34,5 @@ Or if you know how to make a pull request
 ## Status
 |  Locale  |  Lines  | % Done|
 |----------|---------|-------|
-| Template |      18 |       |
-| nl_NL    |   18/18 |  100% |
+| Template |      17 |       |
+| nl_NL    |   17/17 |  100% |

--- a/package/translate/nl_NL.po
+++ b/package/translate/nl_NL.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: todolist\n"
 "Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-todolist\n"
-"POT-Creation-Date: 2019-03-13 19:33-0400\n"
+"POT-Creation-Date: 2019-06-25 19:47+0200\n"
 "PO-Revision-Date: 2019-03-31 17:10+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Dutch <vistausss@outlook.com>\n"
@@ -70,10 +70,7 @@ msgstr "<b>Versie:</b> %1"
 msgid "Open in Text Editor"
 msgstr "Openen in tekstbewerker"
 
-#: ../contents/ui/main.qml:128
-msgid "Add List"
-msgstr "Lijst toevoegen"
-
+#. i18n("Add List"), "list-add")
 #: ../contents/ui/main.qml:129
 msgid "Delete on Complete"
 msgstr "Taken wissen na afronden"
@@ -89,3 +86,6 @@ msgstr "Lijst verwijderen"
 #: ../contents/ui/NoteSection.qml:158
 msgid "Are you sure you want to delete the list \"%1\" with %2 items?"
 msgstr "Weet je zeker dat je de lijst \"%1\", met daarop %2 taken, wilt verwijderen?"
+
+#~ msgid "Add List"
+#~ msgstr "Lijst toevoegen"

--- a/package/translate/template.pot
+++ b/package/translate/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: todolist \n"
 "Report-Msgid-Bugs-To: https://github.com/Zren/plasma-applet-todolist\n"
-"POT-Creation-Date: 2019-03-13 19:33-0400\n"
+"POT-Creation-Date: 2019-06-25 19:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -69,10 +69,7 @@ msgstr ""
 msgid "Open in Text Editor"
 msgstr ""
 
-#: ../contents/ui/main.qml:128
-msgid "Add List"
-msgstr ""
-
+#. i18n("Add List"), "list-add")
 #: ../contents/ui/main.qml:129
 msgid "Delete on Complete"
 msgstr ""


### PR DESCRIPTION
This import is unused since all mentions of PlasmaComponents3 in the code are
comment out.
Moreover it makes the widget bug on Debian 9 if the widget is install from KDE
widget store.

By the way, thank you for this pretty cool widget!