### PR TITLE
WIP: Added possibility for custom note name

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -6,7 +6,13 @@
 		<entry name="useGlobalNote" type="bool">
 			<default>true</default>
 		</entry>
-		<entry name="noteId" type="string">
+               <entry name="useOwnNameNote" type="bool">
+			<default>true</default>
+		</entry>
+		<entry name="noteName" type="string">
+			<default></default>
+		</entry>
+               <entry name="noteId" type="string">
 			<default></default>
 		</entry>
 		<entry name="showCompletedItems" type="Bool">

--- a/package/contents/ui/NoteItem.qml
+++ b/package/contents/ui/NoteItem.qml
@@ -9,7 +9,11 @@ Item {
 		if (plasmoid.configuration.useGlobalNote) {
 			return 'todolist'
 		} else { // instanceNoteId
-			return 'todolist_' + plasmoid.id
+            if (plasmoid.configuration.useOwnNameNote) {
+                return plasmoid.configuration.noteName
+            } else {
+                return 'todolist_' + plasmoid.id
+            }
 		}
 	}
 	onNoteIdChanged: {

--- a/package/contents/ui/config/ConfigGeneral.qml
+++ b/package/contents/ui/config/ConfigGeneral.qml
@@ -25,6 +25,29 @@ ConfigPage {
 
 	ConfigSection {
 		Label {
+			text: i18n("Note Name")
+			font.weight: Font.Bold
+			font.pointSize: theme.defaultFont.pointSize * 1.25
+		}
+
+		ConfigCheckBox {
+			configKey: 'useGlobalNote'
+			text: i18n("Use Global Note")
+		}
+
+		ConfigCheckBox {
+			configKey: 'useOwnNameNote'
+			text: i18n("Use Own Name for the Note")
+		}
+
+		ConfigTextField {
+			configKey: 'noteName'
+			placeholderText: i18n("Note Name")
+		}
+	}
+
+	ConfigSection {
+		Label {
 			text: i18n("Completed Items")
 			font.weight: Font.Bold
 			font.pointSize: theme.defaultFont.pointSize * 1.25

--- a/package/contents/ui/lib/ConfigTextField.qml
+++ b/package/contents/ui/lib/ConfigTextField.qml
@@ -1,0 +1,16 @@
+import QtQuick 2.0
+import QtQuick.Controls 1.0
+import QtQuick.Layouts 1.0
+
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.components 2.0 as PlasmaComponents
+
+import ".."
+
+TextField {
+	id: configTextField
+
+	property string configKey: ''
+	text: plasmoid.configuration[configKey]
+	onAccepted: plasmoid.configuration[configKey] = text
+}

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -84,7 +84,7 @@ Item {
 	}
 
 	function action_openInTextEditor() {
-		exec("xdg-open ~/.local/share/plasma_notes/todolist")
+		exec("xdg-open ~/.local/share/plasma_notes/" + plasmoid.configuration.noteId)
 	}
 
 	function action_addSection() {


### PR DESCRIPTION
Hi all,

@Zren: first of all thank you for the greate applet :) I am using it daily and it is great to have short todos one-click away :)

I added possibility to define custom note name. This is WIP, but I wanted to share with you to check if this is direction where you want to go. This feature was asked frequently and it is very useful since now it make since to create multiple lists (e.g. home and work).

**Note**: When new list name is entered, one need to "accept" it with <CTRL>+<ENTER> keys to be stored in configuration. Also one need to restart plasma to get it switched in the applet. to do this I am using:
```
killall -9 plasmashell
plasmashell
```

I hope you find this useful and maybe we can adapt it to functions more user-friendly.