### PR TITLE
Fix the bug about setting the note filename

### DIFF
--- a/package/contents/ui/NoteItem.qml
+++ b/package/contents/ui/NoteItem.qml
@@ -18,7 +18,10 @@ Item {
 	onNoteIdChanged: {
 		// console.log('[todolist] onNoteIdChanged', noteId)
 		if (!noteItem.note || noteItem.note.id != noteId) {
+			deboucedSaveNoteTimer.stop()
+			saveNote()
 			noteItem.note = noteManager.loadNote(noteId)
+			noteItem.loadNote()
 		}
 		plasmoid.configuration.noteId = noteId
 	}

--- a/package/contents/ui/lib/ConfigString.qml
+++ b/package/contents/ui/lib/ConfigString.qml
@@ -1,8 +1,12 @@
-// Version 2
+// Version 3
 
 import QtQuick 2.0
 import QtQuick.Controls 1.0
 import QtQuick.Layouts 1.0
+import QtQuick.Dialogs 1.2
+import org.kde.plasma.components 2.0 as PlasmaComponents
+import org.kde.plasma.core 2.0 as PlasmaCore
+import org.kde.plasma.private.notes 0.1 as NotesWidget
 
 TextField {
 	id: configString
@@ -17,9 +21,28 @@ TextField {
 		}
 	}
 	property string defaultValue: ""
+	property string overlayTempValue: ""
+	property bool overlayVisible: false
 
+	// Don't update on text change real-time, to avoid accidentally overwriting unexpected files
 	text: configString.configValue
-	onTextChanged: serializeTimer.restart()
+
+	// Disable direct editing of the text field
+	readOnly: true
+
+	// Show the overlay when clicked
+	MouseArea {
+		anchors.fill: parent
+		onClicked: {
+			if (!overlayVisible) {
+				overlayTempValue = text
+				overlayTextField.text = text
+				overlayVisible = true
+				overlayTextField.forceActiveFocus()
+			}
+		}
+		enabled: !overlayVisible
+	}
 
 	ToolButton {
 		iconName: "edit-clear"
@@ -30,15 +53,143 @@ TextField {
 		anchors.bottom: parent.bottom
 
 		width: height
+		visible: !overlayVisible
 	}
 
-	Timer { // throttle
-		id: serializeTimer
-		interval: 300
-		onTriggered: {
-			if (configKey) {
-				plasmoid.configuration[configKey] = value
+	// Overlay component for editing
+	Rectangle {
+		id: editOverlay
+		anchors.fill: parent
+		color: theme.backgroundColor
+		border.color: theme.highlightColor
+		border.width: 1
+		radius: 3
+		visible: overlayVisible
+		z: 10
+
+		// Handle key events at the overlay level to ensure they work
+		// even if the text field doesn't have focus
+		Keys.enabled: overlayVisible
+		Keys.onEscapePressed: cancelEdit()
+		Keys.onReturnPressed: confirmEdit()
+		Keys.onEnterPressed: confirmEdit()
+
+		TextField {
+			id: overlayTextField
+			anchors.left: parent.left
+			anchors.right: confirmButton.left
+			anchors.verticalCenter: parent.verticalCenter
+			anchors.margins: 5
+			text: configString.overlayTempValue
+			placeholderText: configString.placeholderText
+
+			// Also handle keys at the TextField level
+			Keys.onEscapePressed: cancelEdit()
+			Keys.onReturnPressed: confirmEdit()
+			Keys.onEnterPressed: confirmEdit()
+		}
+
+		ToolButton {
+			id: confirmButton
+			iconName: "dialog-ok"
+			anchors.right: cancelButton.left
+			anchors.top: parent.top
+			anchors.bottom: parent.bottom
+			width: height
+			onClicked: confirmEdit()
+			
+			// Add a green rectangle behind the icon
+			Rectangle {
+				anchors.fill: parent
+				anchors.margins: 4
+				color: "#4CAF50"  // Green color
+				radius: 3
+				z: -1  // Place behind the icon
+				opacity: 0.7
 			}
 		}
+
+		ToolButton {
+			id: cancelButton
+			iconName: "dialog-cancel"
+			anchors.right: parent.right
+			anchors.top: parent.top
+			anchors.bottom: parent.bottom
+			width: height
+			onClicked: cancelEdit()
+			
+			// Add a red rectangle behind the icon
+			Rectangle {
+				anchors.fill: parent
+				anchors.margins: 4
+				color: "#F44336"  // Red color
+				radius: 3
+				z: -1  // Place behind the icon
+				opacity: 0.7
+			}
+		}
+	}
+
+	// Confirmation dialog
+	MessageDialog {
+		id: confirmationDialog
+		title: i18n("Confirm Overwrite")
+		text: i18n("File already exists. Do you want to choose it?")
+		standardButtons: StandardButton.Yes | StandardButton.No
+
+		onYes: {
+			applyChanges()
+		}
+
+		onNo: {
+			// Do nothing, keep the overlay open
+		}
+	}
+
+	MessageDialog {
+        id: msgCannotWrite
+        title: i18n("Error")
+        text: i18n("Cannot write to the choosen file!")
+        icon: StandardIcon.Critical
+        standardButtons: StandardButton.Ok
+    }
+
+	// Since we don't have direct access to check if a file exists,
+	// we'll use a workaround by creating a temporary NoteManager
+	// and trying to load the note
+	NotesWidget.NoteManager { id: tempNoteManager }
+	function fileExists(filename) {
+		try {
+			var note = tempNoteManager.loadNote(filename);
+			return note && note.noteText !== "";
+		} catch (e) {
+			// If there's an error loading the note, assume the file doesn't exist
+			return false;
+		}
+	}
+
+	function confirmEdit() {
+		// Only check file for 'noteFilename'
+		if (configKey === "noteFilename") {
+			if (fileExists(overlayTextField.text)) {
+				confirmationDialog.open()
+			} else {
+				applyChanges()
+			}
+		} else {
+			applyChanges()
+		}
+	}
+
+	function applyChanges() {
+		if (configKey) {
+			value = overlayTextField.text
+			plasmoid.configuration[configKey] = value
+		}
+		overlayVisible = false
+	}
+
+	function cancelEdit() {
+		overlayVisible = false
 	}
 }


### PR DESCRIPTION
Fixed bugs related to changing the "Note Filename" text field:
**bug1**: The old file’s debounced changes weren’t being saved correctly.
**bug2**: The new note wasn’t loading or showing properly.

To reproduce the bug2:
1. Add a new TODOList widget to the desktop
2. Randomly modify any TODO item.
3. Create a non-empty todo.txt file.
4. Open the TODOList configure page, uncheck the "Use Global Note" option in the general settings, and set the note filename to the newly created todo.txt file. 

Observations:
1. The items previously written into todo.txt are not loaded or displayed;
2. Any subsequent modification to the todo items results in the original todo.txt being overwritten, causing data loss.

---

To reproduce bug1:
1. Increase the interval of debouncedSaveNoteTimer (e.g., to 10000) for easier observation.
2. Run plasmoidviewer --applet package.
3. Modify any TODO item.
5. Open the TODOList configure page, uncheck "Use Global Note," and set the note filename to a non-default path (Within 10 seconds, i.e., the interval of the debouncedSaveNoteTimer).
6. Wait longer than the specified interval.

Observations:
Open the default note file; the previous modifications will not be saved, causing data loss.

---

Additionally, add an overlay editor for the node filename to prevent accidental overwriting of unintended files while typing the filename.